### PR TITLE
#162110235 change the present location of the order

### DIFF
--- a/server/controllers/parcels.js
+++ b/server/controllers/parcels.js
@@ -15,7 +15,7 @@ const getAll = (req, res) => {
   Parcel.find(sender !== null ? { sender, ...req.query } : req.query)
     .then(parcels => (parcels.length
       ? res.status(200).json({ error: null, parcels })
-      : res.status(204).json({ error: { message: 'no content' } })))
+      : res.status(204).json({ error: { message: 'No content' } })))
     .catch(err => res.status(400).json({ error: err }));
 };
 
@@ -41,7 +41,7 @@ const updateParcel = (req, res) => {
         ) {
           res.status(400).json({
             error: {
-              message: "can't update the delivered or cancelled order",
+              message: "Can't update the delivered or cancelled order",
               name: 'ValidationError'
             }
           });
@@ -57,7 +57,7 @@ const updateParcel = (req, res) => {
       .catch(err => res.status(400).json({ error: err }));
   } else {
     return res.status(400).json({
-      error: { message: "can't empty the record", name: 'ValidationError' }
+      error: { message: "Can't empty the record", name: 'ValidationError' }
     });
   }
 };

--- a/server/controllers/parcels.js
+++ b/server/controllers/parcels.js
@@ -49,14 +49,14 @@ const updateParcel = (req, res) => {
           Parcel.update({ ...req.body }, { id })
             .then(parcels => {
               const [parcel] = parcels;
-              res.status(201).json({ error: null, parcel });
+              return res.status(201).json({ error: null, parcel });
             })
             .catch(err => res.status(400).json({ error: err }));
         }
       })
       .catch(err => res.status(400).json({ error: err }));
   } else {
-    res.status(400).json({
+    return res.status(400).json({
       error: { message: "can't empty the record", name: 'ValidationError' }
     });
   }

--- a/server/routes/parcels.js
+++ b/server/routes/parcels.js
@@ -33,9 +33,9 @@ parcels.put(
   updateParcel
 );
 
-// /*********** CHANGE THE ORDER'S STATUS *************************************/
+// /*********** CHANGE THE ORDER'S PRESENTLOCATION ****************************/
 
-parcels.put(`${entry}/:id/status`, updateParcel);
+parcels.put(`${entry}/:id/presentLocation`, updateParcel);
 
 // /************************ END OF PARCELS APIs ******************************/
 


### PR DESCRIPTION
## What does this PR do (?)

It makes the admin able to change the present location of the order.

## Description of Task to be completed (?)

The following route should be working to enable the admin to change the present location of the parcel.

- PUT /parcels/<parcel_id>/presentLocation

## How should this be manually tested (?)

After cloning this repo and switch to this branch, Install the project dependencies with the Node package manager of your choice,

- Using any RESTful Client tool (Usually the postman), Provide the target parcel_id within your request URL, you also need to set the new present_location within the request body.
- You should get the response that contains the target parcel information with the updated present_location.

-Beware to spell the present location correctly like the following: **present_location**

Key: Content-Type value: application/json

## Any background context you want to provide (?)

I'm using ES6 features in this branch, please be aware of the transpiler (.babelrc file) configurations.

## What are the relevant pivotal tracker stories (?)

1. 162110235

