### PR TITLE
[Feature #163357540] Cancel the parcel delivery order

### DIFF
--- a/UI/js/client/cancel-order.js
+++ b/UI/js/client/cancel-order.js
@@ -1,0 +1,24 @@
+import Helpers from '../helpers/index.js';
+
+const token = localStorage.getItem('token');
+
+window.cancelOrder = parcelId => {
+  fetch(`${Helpers.baseURL()}/parcels/${parcelId}/cancel`, {
+    method: 'PUT',
+    headers: {
+      'Content-type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    mode: 'cors',
+    cache: 'default'
+  })
+    .then(async res => {
+      const body = await res.json();
+      if (res.status === 201) window.location.reload();
+      else if (res.status === 400) Helpers.toggleToast(body.message);
+      else if (res.status === 401) window.location = '../../pages/auth/login.html';
+      else if (res.status > 401 && res.status < 500) Helpers.toggleToast(body.message);
+      else if (res.status >= 500) Helpers.toggleToast(undefined, { type: 'error' });
+    })
+    .catch(() => Helpers.toggleToast(undefined, { type: 'error' }));
+};

--- a/UI/js/client/index.js
+++ b/UI/js/client/index.js
@@ -72,6 +72,7 @@ fetch(`${Helpers.baseURL()}/parcels`, {
         toShow += hidden
           ? ''
           : `<img
+              onclick="cancelOrder(${parcel.id})"
               class="hover"
               src="../../assets/icons/x-button.png"
               alt="lg"

--- a/UI/js/common.js
+++ b/UI/js/common.js
@@ -1,9 +1,10 @@
-const cancelOrder = element => {
-  element.parentElement.parentElement.hidden = true;
-};
-
 const openModal = (id, parcelId = 0) => {
-  if (parcelId) document.getElementById('parcel-id').value = parcelId;
+  if (parcelId) {
+    document.getElementById('parcel-id').value = parcelId;
+    document.getElementById(
+      'dest'
+    ).firstElementChild.innerHTML = `updating the order n\u00B0 ${parcelId}`;
+  }
   document.getElementById(id).style.display = 'flex';
 };
 

--- a/UI/pages/client/index.html
+++ b/UI/pages/client/index.html
@@ -28,6 +28,7 @@
     <script type="module" src="../../js/client/index.js"></script>
     <script type="module" src="../../js/client/new-order.js"></script>
     <script type="module" src="../../js/client/change-dest.js"></script>
+    <script type="module" src="../../js/client/cancel-order.js"></script>
     <section class="top-nav">
       <div class="top-nav-right">
         <div class="notif-container">
@@ -147,8 +148,8 @@
     </section>
 
     <section class="modal change-dest" id="edit-dest">
-      <div class="modal-header">
-        Add the new destination
+      <div id="dest" class="modal-header">
+        <p></p>
         <img
           onclick="closeModal('edit-dest')"
           src="../../assets/icons/x-button.png"


### PR DESCRIPTION
## What does this PR do (?)
It helps the logged in user to cancel any of his/her undelivered parcel delivery orders.
## Description of Task to be completed (?)
The user should be able to cancel any of his/her undelivered parcel orders from his/her account.
On a tabular list of all parcels, there's a cancel icon in the right side of every row.
By the time the user clicks on the cancel button, the target order should be canceled.
## How should this be manually tested (?)
After cloning this repository and head to this branch,

- Remember to tweak your database credentials via config directory.
- Start your web pages using any browser as a debugger.
- Create an account if you haven't yet and try logging out to see or
- Log into the application using the right credentials if you already have an account,
- Locate and click the red **X** icon on the right side of every row.
- The target order must be canceled. 

## Any background context you want to provide (?)
I'm using ES6 features, bear with it and run the build command yarn build if needed and change the package.json to match every command setup.

## What are the relevant pivotal tracker stories (?)
- 163357540